### PR TITLE
Build a single regex for other filter types for speed

### DIFF
--- a/src/Shifter/Filter/FileFilter.php
+++ b/src/Shifter/Filter/FileFilter.php
@@ -25,10 +25,8 @@ use Asmblah\PhpCodeShift\Shifter\Stream\Native\StreamWrapper;
  */
 class FileFilter implements FileFilterInterface
 {
-    /**
-     * @var string
-     */
-    private string $regex;
+    private readonly string $regex;
+    private readonly string $regexPart;
 
     public function __construct(
         private readonly string $pattern
@@ -50,7 +48,8 @@ class FileFilter implements FileFilterInterface
             $patterns[] = $protocol . '://' . $pattern;
         }
 
-        $this->regex = '#\A(?:' . implode('|', $patterns) . ')\Z#';
+        $this->regexPart = implode('|', $patterns);
+        $this->regex = '#\A(?:' . $this->regexPart . ')\Z#';
     }
 
     /**
@@ -80,5 +79,13 @@ class FileFilter implements FileFilterInterface
     public function getRegex(): string
     {
         return $this->regex;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getRegexPart(): string
+    {
+        return $this->regexPart;
     }
 }

--- a/src/Shifter/Filter/FileFilterInterface.php
+++ b/src/Shifter/Filter/FileFilterInterface.php
@@ -26,4 +26,10 @@ interface FileFilterInterface
      * Determines whether the given file path matches this filter.
      */
     public function fileMatches(string $path): bool;
+
+    /**
+     * Fetches a regex for matching this filter without delimiters etc.,
+     * suitable to be built into a larger single regex.
+     */
+    public function getRegexPart(): string;
 }

--- a/tests/Unit/Shifter/Filter/DenyListTest.php
+++ b/tests/Unit/Shifter/Filter/DenyListTest.php
@@ -33,16 +33,16 @@ class DenyListTest extends AbstractTestCase
 
     public function testClearRemovesAllFilters(): void
     {
-        $filter = mock(FileFilterInterface::class);
-        $filter->allows()
-            ->fileMatches('/my/path.php')
-            ->andReturn(true);
+        $filter = mock(FileFilterInterface::class, [
+            'getRegexPart' => '\/my\/path\.php',
+        ]);
         $this->denyList->addFilter($filter);
 
         $this->denyList->clear();
 
         // Would have been allowed had we not cleared the list just above.
         static::assertFalse($this->denyList->fileMatches('/my/path.php'));
+        static::assertSame('(?!)', $this->denyList->getRegexPart());
     }
 
     public function testFileMatchesReturnsFalseWhenThereAreNoFiltersInTheList(): void
@@ -52,10 +52,9 @@ class DenyListTest extends AbstractTestCase
 
     public function testFileMatchesReturnsFalseWhenThereAreNoMatchingFiltersInTheList(): void
     {
-        $filter = mock(FileFilterInterface::class);
-        $filter->allows()
-            ->fileMatches('/my/path.php')
-            ->andReturn(false);
+        $filter = mock(FileFilterInterface::class, [
+            'getRegexPart' => '\/your\/path\.php',
+        ]);
         $this->denyList->addFilter($filter);
 
         static::assertFalse($this->denyList->fileMatches('/my/path.php'));
@@ -63,12 +62,44 @@ class DenyListTest extends AbstractTestCase
 
     public function testFileMatchesReturnsTrueWhenThereIsAMatchingFilterInTheList(): void
     {
-        $filter = mock(FileFilterInterface::class);
-        $filter->allows()
-            ->fileMatches('/my/path.php')
-            ->andReturn(true);
+        $filter = mock(FileFilterInterface::class, [
+            'getRegexPart' => '\/my\/path\.php',
+        ]);
         $this->denyList->addFilter($filter);
 
         static::assertTrue($this->denyList->fileMatches('/my/path.php'));
+    }
+
+    public function testGetFiltersFetchesAddedFilters(): void
+    {
+        $filter1 = mock(FileFilterInterface::class, [
+            'getRegexPart' => '(?:abc)',
+        ]);
+        $filter2 = mock(FileFilterInterface::class, [
+            'getRegexPart' => '(?:def)',
+        ]);
+        $this->denyList->addFilter($filter1);
+        $this->denyList->addFilter($filter2);
+
+        static::assertSame([$filter1, $filter2], $this->denyList->getFilters());
+    }
+
+    public function testGetRegexPartReturnsEmptyNegativeLookaheadToForceFailureInitially(): void
+    {
+        static::assertSame('(?!)', $this->denyList->getRegexPart());
+    }
+
+    public function testGetRegexPartReturnsCorrectPatternWithMultipleFilters(): void
+    {
+        $filter1 = mock(FileFilterInterface::class, [
+            'getRegexPart' => '\/my\/first\.php',
+        ]);
+        $this->denyList->addFilter($filter1);
+        $filter2 = mock(FileFilterInterface::class, [
+            'getRegexPart' => '\/my\/second\.php',
+        ]);
+        $this->denyList->addFilter($filter2);
+
+        static::assertSame('\/my\/first\.php|\/my\/second\.php', $this->denyList->getRegexPart());
     }
 }

--- a/tests/Unit/Shifter/Filter/FileFilterTest.php
+++ b/tests/Unit/Shifter/Filter/FileFilterTest.php
@@ -185,4 +185,14 @@ class FileFilterTest extends AbstractTestCase
             $filter->getRegex()
         );
     }
+
+    public function testGetRegexPartFetchesTheRawRegexPart(): void
+    {
+        $filter = new FileFilter('my/**/patt*ern');
+
+        static::assertSame(
+            'my/[\s\S]*?/patt[^/]*?ern|file://my/[\s\S]*?/patt[^/]*?ern|phar://my/[\s\S]*?/patt[^/]*?ern',
+            $filter->getRegexPart()
+        );
+    }
 }

--- a/tests/Unit/Shifter/Filter/MultipleFilterTest.php
+++ b/tests/Unit/Shifter/Filter/MultipleFilterTest.php
@@ -13,10 +13,11 @@ declare(strict_types=1);
 
 namespace Asmblah\PhpCodeShift\Tests\Unit\Shifter\Filter;
 
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
 use Asmblah\PhpCodeShift\Shifter\Filter\FileFilterInterface;
 use Asmblah\PhpCodeShift\Shifter\Filter\MultipleFilter;
 use Asmblah\PhpCodeShift\Tests\AbstractTestCase;
-use Mockery\MockInterface;
+use Generator;
 
 /**
  * Class MultipleFilterTest.
@@ -25,42 +26,102 @@ use Mockery\MockInterface;
  */
 class MultipleFilterTest extends AbstractTestCase
 {
-    private MultipleFilter $filter;
-    private MockInterface&FileFilterInterface $subFilter1;
-    private MockInterface&FileFilterInterface $subFilter2;
+    /**
+     * @dataProvider fileMatchesProvider
+     * @param FileFilterInterface[] $subFilters
+     * @param string $path
+     * @param bool $expectedResult
+     */
+    public function testFileMatchesReturnsCorrectResult(
+        array $subFilters,
+        string $path,
+        bool $expectedResult
+    ): void {
+        $filter = new MultipleFilter($subFilters);
 
-    public function setUp(): void
+        static::assertSame($expectedResult, $filter->fileMatches($path));
+    }
+
+    public static function fileMatchesProvider(): Generator
     {
-        $this->subFilter1 = mock(FileFilterInterface::class, [
-            'fileMatches' => false,
+        yield 'single sub-filter, matching implicit file protocol with star' => [
+            [new FileFilter('/my/path/to*.txt')],
+            '/my/path/to_my_file.txt',
+            true,
+        ];
+
+        yield 'single sub-filter, non-matching implicit file protocol with star' => [
+            [new FileFilter('/my/path/to*.txt')],
+            '/my/path/to/my_file.txt',
+            false,
+        ];
+
+        yield 'single sub-filter, matching explicit Phar protocol' => [
+            [new FileFilter('/my/path/*/it.txt')],
+            'phar:///my/path/to/it.txt',
+            true,
+        ];
+
+        yield 'single sub-filter, non-matching explicit Phar protocol' => [
+            [new FileFilter('/my/path/*/it.txt')],
+            'phar:///my/path/to/not_it.txt',
+            false,
+        ];
+
+        yield 'two sub-filters, only first one matches' => [
+            [new FileFilter('/my/path/to*.txt'), new FileFilter('/your/path/here')],
+            '/my/path/to_my_file.txt',
+            true,
+        ];
+
+        yield 'two sub-filters, only second one matches' => [
+            [new FileFilter('/your/path/here'), new FileFilter('/my/path/to*.txt')],
+            '/my/path/to_my_file.txt',
+            true,
+        ];
+
+        yield 'two sub-filters, neither matches' => [
+            [new FileFilter('/my/path/to/somewhere_else.txt'), new FileFilter('/your/path/here')],
+            '/my/path/to_my_file.txt',
+            false,
+        ];
+    }
+
+    public function testGetRegexPartFetchesTheRawRegexPartWithOneSubFilter(): void
+    {
+        $filter = new MultipleFilter([new FileFilter('my/**/patt*ern')]);
+
+        static::assertSame(
+            'my/[\s\S]*?/patt[^/]*?ern|file://my/[\s\S]*?/patt[^/]*?ern|phar://my/[\s\S]*?/patt[^/]*?ern',
+            $filter->getRegexPart()
+        );
+    }
+
+    public function testGetRegexPartFetchesTheRawRegexPartWithTwoSubFilters(): void
+    {
+        $filter = new MultipleFilter([
+            new FileFilter('my/**/patt*ern'),
+            new FileFilter('your/**/patt*ern'),
         ]);
-        $this->subFilter2 = mock(FileFilterInterface::class, [
-            'fileMatches' => false,
+
+        static::assertSame(
+            'my/[\s\S]*?/patt[^/]*?ern|file://my/[\s\S]*?/patt[^/]*?ern|phar://my/[\s\S]*?/patt[^/]*?ern|' .
+            'your/[\s\S]*?/patt[^/]*?ern|file://your/[\s\S]*?/patt[^/]*?ern|phar://your/[\s\S]*?/patt[^/]*?ern',
+            $filter->getRegexPart()
+        );
+    }
+
+    public function testGetSubFiltersFetchesThem(): void
+    {
+        $subFilter1 = mock(FileFilterInterface::class, [
+            'getRegexPart' => '(?:abc)',
+        ]);
+        $subFilter2 = mock(FileFilterInterface::class, [
+            'getRegexPart' => '(?:def)',
         ]);
 
-        $this->filter = new MultipleFilter([$this->subFilter1, $this->subFilter2]);
-    }
+        $subFilters = (new MultipleFilter([$subFilter1, $subFilter2]))->getSubFilters();
 
-    public function testFileMatchesReturnsTrueWhenFirstSubFilterMatches(): void
-    {
-        $this->subFilter1->allows()
-            ->fileMatches('/my/path/to/my_module.php')
-            ->andReturnTrue();
-
-        static::assertTrue($this->filter->fileMatches('/my/path/to/my_module.php'));
-    }
-
-    public function testFileMatchesReturnsTrueWhenSecondSubFilterMatches(): void
-    {
-        $this->subFilter2->allows()
-            ->fileMatches('/my/path/to/my_module.php')
-            ->andReturnTrue();
-
-        static::assertTrue($this->filter->fileMatches('/my/path/to/my_module.php'));
-    }
-
-    public function testFileMatchesReturnsFalseWhenNoSubFilterMatches(): void
-    {
-        static::assertFalse($this->filter->fileMatches('/my/path/to/some_module.php'));
+        static::assertSame([$subFilter1, $subFilter2], $subFilters);
     }
 }


### PR DESCRIPTION
Optimises file filtering by building and using a single regex wherever possible, rather than recursive `->fileMatches(...)` calls invoking `preg_match(...)` multiple times.