### PR TITLE
Add structured API for registering stream handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,70 @@ my replacement string
 
 Static method calls (`MyClass::myStaticMethod()`) and class constant fetches (`MyClass:MY_CONST`) are also supported.
 
+### Custom stream handlers
+Filesystem access is intercepted using a stream wrapper for the special `file://` and `phar://` protocols.
+By default, the stream wrapper uses a stream _handler_ (a PHP Code Shift -specific concept)
+that for the most part delegates to PHP's native filesystem handling.
+A custom stream handler may be registered in its place in order to hook into filesystem operations.
+
+See [Nytris Antilag][4] and [Nytris Boost][5] for examples of libraries that register custom stream handlers.
+
+#### Example
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace My\App;
+
+use Asmblah\PhpCodeShift\CodeShift;
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Asmblah\PhpCodeShift\Shifter\Shift\Shift\ClassHook\ClassHookShiftSpec;
+use Asmblah\PhpCodeShift\Shifter\Stream\Handler\AbstractStreamHandlerDecorator;
+use Asmblah\PhpCodeShift\Shifter\Stream\Handler\Registration\RegistrantInterface;
+use Asmblah\PhpCodeShift\Shifter\Stream\Handler\Registration\Registration;
+use Asmblah\PhpCodeShift\Shifter\Stream\Handler\Registration\RegistrationInterface;
+use Asmblah\PhpCodeShift\Shifter\Stream\Handler\StreamHandlerInterface;
+use Asmblah\PhpCodeShift\Shifter\Stream\Native\StreamWrapperInterface;
+use Asmblah\PhpCodeShift\Shifter\Stream\StreamWrapperManager;
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+class MyStreamHandler extends AbstractStreamHandlerDecorator
+{
+    public function unlink(StreamWrapperInterface $streamWrapper, string $path): bool
+    {
+        print 'Unlinking path: ' . $path . PHP_EOL;
+
+        return parent::unlink($streamWrapper, $path);
+    }
+}
+
+class MyRegistrant implements RegistrantInterface
+{
+    public function registerStreamHandler(
+        StreamHandlerInterface $currentStreamHandler,
+        ?StreamHandlerInterface $previousStreamHandler
+    ): RegistrationInterface {
+        return new Registration(
+            streamHandler: new MyStreamHandler($currentStreamHandler),
+            // Usually, the $previousStreamHandler passed to this method will not be of use,
+            // instead the "current" stream handler should be used as that will become the previous one.
+            previousStreamHandler: $currentStreamHandler
+        );
+    }
+}
+
+$codeShift = new CodeShift();
+$codeShift->install();
+
+StreamWrapperManager::registerStreamHandler(new MyRegistrant());
+
+touch('my_file.txt');
+unlink('my_file.txt'); // Will print "Unlinking path: my_file.txt".
+```
+
 ## Limitations
 Functionality is extremely limited at the moment, you may well be better off using one of the alternatives
 listed in [See also](#see-also) below.
@@ -142,3 +206,5 @@ listed in [See also](#see-also) below.
 [1]: https://github.com/dg/bypass-finals
 [2]: https://github.com/ircmaxell/php-preprocessor
 [3]: https://github.com/antecedent/patchwork
+[4]: https://github.com/nytris/antilag
+[5]: https://github.com/nytris/boost

--- a/src/Shifter/Stream/Handler/AbstractStreamHandlerDecorator.php
+++ b/src/Shifter/Stream/Handler/AbstractStreamHandlerDecorator.php
@@ -64,6 +64,14 @@ abstract class AbstractStreamHandlerDecorator implements StreamHandlerInterface
     /**
      * @inheritDoc
      */
+    public function redecorate(StreamHandlerInterface $newWrappedStreamHandler): void
+    {
+        $this->wrappedStreamHandler = $newWrappedStreamHandler;
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function rewindDir(StreamWrapperInterface $streamWrapper): bool
     {
         return $this->wrappedStreamHandler->rewindDir($streamWrapper);

--- a/src/Shifter/Stream/Handler/Registration/AbstractRegistration.php
+++ b/src/Shifter/Stream/Handler/Registration/AbstractRegistration.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * PHP Code Shift - Monkey-patch PHP code on the fly.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/php-code-shift/
+ *
+ * Released under the MIT license.
+ * https://github.com/asmblah/php-code-shift/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Asmblah\PhpCodeShift\Shifter\Stream\Handler\Registration;
+
+use Asmblah\PhpCodeShift\Shifter\Stream\Handler\StreamHandlerInterface;
+use Asmblah\PhpCodeShift\Shifter\Stream\StreamWrapperManager;
+
+/**
+ * Class AbstractRegistration.
+ *
+ * Represents a stream handler to be registered.
+ *
+ * @template T of StreamHandlerInterface
+ * @template-implements RegistrationInterface<T>
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+abstract class AbstractRegistration implements RegistrationInterface
+{
+    /**
+     * @phpstan-param T $streamHandler
+     */
+    public function __construct(
+        protected readonly StreamHandlerInterface $streamHandler,
+        protected readonly StreamHandlerInterface $previousStreamHandler
+    ) {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getStreamHandler(): StreamHandlerInterface
+    {
+        return $this->streamHandler;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function redecorate(StreamHandlerInterface $newWrappedStreamHandler): void
+    {
+        $this->streamHandler->redecorate($newWrappedStreamHandler);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function register(): void
+    {
+        StreamWrapperManager::setStreamHandler($this->streamHandler);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function replace(RegistrationInterface $replacementRegistration): RegistrationInterface
+    {
+        return $replacementRegistration;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function unregister(): void
+    {
+        // Assuming the stream handler has not changed in the meantime,
+        // restore the stream handler that was in use previously.
+        if (StreamWrapperManager::getStreamHandler() === $this->streamHandler) {
+            StreamWrapperManager::setStreamHandler($this->previousStreamHandler);
+        }
+    }
+}

--- a/src/Shifter/Stream/Handler/Registration/RegistrantInterface.php
+++ b/src/Shifter/Stream/Handler/Registration/RegistrantInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * PHP Code Shift - Monkey-patch PHP code on the fly.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/php-code-shift/
+ *
+ * Released under the MIT license.
+ * https://github.com/asmblah/php-code-shift/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Asmblah\PhpCodeShift\Shifter\Stream\Handler\Registration;
+
+use Asmblah\PhpCodeShift\Shifter\Stream\Handler\StreamHandlerInterface;
+
+/**
+ * Interface RegistrantInterface.
+ *
+ * Creates a new stream handler to replace (usually chained with) the previous one.
+ *
+ * @template T of StreamHandlerInterface
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+interface RegistrantInterface
+{
+    /**
+     * Registers a new stream handler.
+     *
+     * @return RegistrationInterface<T>
+     */
+    public function registerStreamHandler(
+        StreamHandlerInterface $currentStreamHandler,
+        ?StreamHandlerInterface $previousStreamHandler
+    ): RegistrationInterface;
+}

--- a/src/Shifter/Stream/Handler/Registration/Registration.php
+++ b/src/Shifter/Stream/Handler/Registration/Registration.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * PHP Code Shift - Monkey-patch PHP code on the fly.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/php-code-shift/
+ *
+ * Released under the MIT license.
+ * https://github.com/asmblah/php-code-shift/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Asmblah\PhpCodeShift\Shifter\Stream\Handler\Registration;
+
+use Asmblah\PhpCodeShift\Shifter\Stream\Handler\StreamHandlerInterface;
+
+/**
+ * Class Registration.
+ *
+ * Represents a stream handler to be registered.
+ *
+ * @template T of StreamHandlerInterface
+ * @template-extends AbstractRegistration<T>
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class Registration extends AbstractRegistration
+{
+}

--- a/src/Shifter/Stream/Handler/Registration/RegistrationInterface.php
+++ b/src/Shifter/Stream/Handler/Registration/RegistrationInterface.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * PHP Code Shift - Monkey-patch PHP code on the fly.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/php-code-shift/
+ *
+ * Released under the MIT license.
+ * https://github.com/asmblah/php-code-shift/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Asmblah\PhpCodeShift\Shifter\Stream\Handler\Registration;
+
+use Asmblah\PhpCodeShift\Shifter\Stream\Handler\StreamHandlerInterface;
+
+/**
+ * Interface RegistrationInterface.
+ *
+ * Represents a registered stream handler.
+ *
+ * @template-covariant T of StreamHandlerInterface
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+interface RegistrationInterface
+{
+    /**
+     * Fetches the registered stream handler.
+     *
+     * @phpstan-return T
+     */
+    public function getStreamHandler(): StreamHandlerInterface;
+
+    /**
+     * Changes the reference to another stream handler from the handler to the provided new one.
+     */
+    public function redecorate(StreamHandlerInterface $newWrappedStreamHandler): void;
+
+    /**
+     * Performs the registration of the stream handler.
+     */
+    public function register(): void;
+
+    /**
+     * Replaces the registered stream handler with another.
+     *
+     * Usually, the provided replacement registration will be returned,
+     * but a different one can be returned in its place if needed.
+     *
+     * @template S of StreamHandlerInterface
+     * @param RegistrationInterface<S> $replacementRegistration
+     * @return RegistrationInterface<S>
+     */
+    public function replace(RegistrationInterface $replacementRegistration): RegistrationInterface;
+
+    /**
+     * Unregisters the stream handler, restoring the previous one.
+     */
+    public function unregister(): void;
+}

--- a/src/Shifter/Stream/Handler/StreamHandler.php
+++ b/src/Shifter/Stream/Handler/StreamHandler.php
@@ -18,6 +18,7 @@ use Asmblah\PhpCodeShift\Shifter\Stream\Native\StreamWrapperInterface;
 use Asmblah\PhpCodeShift\Shifter\Stream\Shifter\StreamShifterInterface;
 use Asmblah\PhpCodeShift\Shifter\Stream\Unwrapper\UnwrapperInterface;
 use Asmblah\PhpCodeShift\Util\CallStackInterface;
+use LogicException;
 
 /**
  * Class StreamHandler.
@@ -93,6 +94,14 @@ class StreamHandler implements StreamHandlerInterface
     public function readDir(StreamWrapperInterface $streamWrapper): string|false
     {
         return readdir($streamWrapper->getWrappedResource());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function redecorate(StreamHandlerInterface $newWrappedStreamHandler): void
+    {
+        throw new LogicException('The base StreamHandler does not decorate');
     }
 
     /**

--- a/src/Shifter/Stream/Handler/StreamHandlerInterface.php
+++ b/src/Shifter/Stream/Handler/StreamHandlerInterface.php
@@ -51,6 +51,11 @@ interface StreamHandlerInterface extends UnwrapperInterface
     public function readDir(StreamWrapperInterface $streamWrapper): string|false;
 
     /**
+     * Replaces the stream handler that this one wraps with a different one.
+     */
+    public function redecorate(StreamHandlerInterface $newWrappedStreamHandler): void;
+
+    /**
      * Rewinds the directory walk to the beginning.
      */
     public function rewindDir(StreamWrapperInterface $streamWrapper): bool;

--- a/tests/Unit/Shifter/Stream/Handler/Registration/RegistrationTest.php
+++ b/tests/Unit/Shifter/Stream/Handler/Registration/RegistrationTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * PHP Code Shift - Monkey-patch PHP code on the fly.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/php-code-shift/
+ *
+ * Released under the MIT license.
+ * https://github.com/asmblah/php-code-shift/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Asmblah\PhpCodeShift\Tests\Unit\Shifter\Stream\Handler\Registration;
+
+use Asmblah\PhpCodeShift\Shifter\Stream\Handler\Registration\Registration;
+use Asmblah\PhpCodeShift\Shifter\Stream\Handler\Registration\RegistrationInterface;
+use Asmblah\PhpCodeShift\Shifter\Stream\Handler\StreamHandlerInterface;
+use Asmblah\PhpCodeShift\Shifter\Stream\StreamWrapperManager;
+use Asmblah\PhpCodeShift\Tests\AbstractTestCase;
+use Mockery\MockInterface;
+
+/**
+ * Class RegistrationTest.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class RegistrationTest extends AbstractTestCase
+{
+    private MockInterface&StreamHandlerInterface $previousStreamHandler;
+    /**
+     * @var Registration<StreamHandlerInterface>
+     */
+    private Registration $registration;
+    private MockInterface&StreamHandlerInterface $streamHandler;
+
+    public function setUp(): void
+    {
+        $this->previousStreamHandler = mock(StreamHandlerInterface::class);
+        $this->streamHandler = mock(StreamHandlerInterface::class);
+
+        StreamWrapperManager::uninitialise();
+        StreamWrapperManager::initialise();
+
+        $this->registration = new Registration(
+            streamHandler: $this->streamHandler,
+            previousStreamHandler: $this->previousStreamHandler
+        );
+    }
+
+    public function tearDown(): void
+    {
+        StreamWrapperManager::uninitialise();
+    }
+
+    public function testGetStreamHandlerReturnsTheRegisteredHandler(): void
+    {
+        static::assertSame($this->streamHandler, $this->registration->getStreamHandler());
+    }
+
+    public function testRedecorateInvokesRedecorateOnTheStreamHandler(): void
+    {
+        $newWrappedStreamHandler = mock(StreamHandlerInterface::class);
+
+        $this->streamHandler->expects()
+            ->redecorate($newWrappedStreamHandler)
+            ->once();
+
+        $this->registration->redecorate($newWrappedStreamHandler);
+    }
+
+    public function testRegisterSetsTheStreamHandlerOnTheManager(): void
+    {
+        $this->registration->register();
+
+        static::assertSame($this->streamHandler, StreamWrapperManager::getStreamHandler());
+    }
+
+    public function testReplaceReturnsTheProvidedRegistrationByDefault(): void
+    {
+        $newRegistration = mock(RegistrationInterface::class);
+
+        static::assertSame($newRegistration, $this->registration->replace($newRegistration));
+    }
+
+    public function testUnregisterSetsThePreviousStreamHandlerOnTheManagerWhenRegisteredHandlerIsStillCurrent(): void
+    {
+        $this->registration->register();
+
+        $this->registration->unregister();
+
+        static::assertSame($this->previousStreamHandler, StreamWrapperManager::getStreamHandler());
+    }
+
+    public function testUnregisterLeavesManagerUnchangedWhenRegisteredHandlerIsNoLongerCurrent(): void
+    {
+        $differentStreamHandler = mock(StreamHandlerInterface::class);
+        $this->registration->register();
+        StreamWrapperManager::setStreamHandler($differentStreamHandler);
+
+        $this->registration->unregister();
+
+        static::assertSame($differentStreamHandler, StreamWrapperManager::getStreamHandler());
+    }
+}

--- a/tests/Unit/Shifter/Stream/Handler/StreamHandlerTest.php
+++ b/tests/Unit/Shifter/Stream/Handler/StreamHandlerTest.php
@@ -23,6 +23,7 @@ use Asmblah\PhpCodeShift\Shifter\Stream\Unwrapper\UnwrapperInterface;
 use Asmblah\PhpCodeShift\Tests\AbstractTestCase;
 use Asmblah\PhpCodeShift\Util\CallStackInterface;
 use Generator;
+use LogicException;
 use Mockery;
 use Mockery\MockInterface;
 
@@ -98,6 +99,16 @@ class StreamHandlerTest extends AbstractTestCase
                 StreamHandlerInterface::STREAM_OPEN_FOR_INCLUDE
             )
         );
+    }
+
+    public function testRedecorateRaisesException(): void
+    {
+        $newWrappedStreamHandler = mock(StreamHandlerInterface::class);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The base StreamHandler does not decorate');
+
+        $this->streamHandler->redecorate($newWrappedStreamHandler);
     }
 
     public function testShiftFileShiftsViaStreamShifter(): void

--- a/tests/Unit/Shifter/Stream/StreamWrapperManagerTest.php
+++ b/tests/Unit/Shifter/Stream/StreamWrapperManagerTest.php
@@ -13,9 +13,13 @@ declare(strict_types=1);
 
 namespace Asmblah\PhpCodeShift\Tests\Unit\Shifter\Stream;
 
+use Asmblah\PhpCodeShift\Shifter\Stream\Handler\Registration\RegistrantInterface;
+use Asmblah\PhpCodeShift\Shifter\Stream\Handler\Registration\RegistrationInterface;
 use Asmblah\PhpCodeShift\Shifter\Stream\Handler\StreamHandlerInterface;
 use Asmblah\PhpCodeShift\Shifter\Stream\StreamWrapperManager;
 use Asmblah\PhpCodeShift\Tests\AbstractTestCase;
+use LogicException;
+use Mockery\MockInterface;
 
 /**
  * Class StreamWrapperManagerTest.
@@ -69,6 +73,100 @@ class StreamWrapperManagerTest extends AbstractTestCase
         StreamWrapperManager::uninitialise();
 
         static::assertFalse(StreamWrapperManager::isInitialised());
+    }
+
+    public function testRegisterStreamHandlerPerformsFirstRegistrationCorrectly(): void
+    {
+        $newStreamHandler = mock(StreamHandlerInterface::class);
+        /** @var MockInterface&RegistrantInterface<StreamHandlerInterface> $registrant */
+        $registrant = mock(RegistrantInterface::class);
+        /** @var MockInterface&RegistrationInterface<StreamHandlerInterface> $registration */
+        $registration = mock(RegistrationInterface::class, [
+            'getStreamHandler' => $newStreamHandler,
+        ]);
+        StreamWrapperManager::initialise();
+
+        $registrant->expects()
+            ->registerStreamHandler(
+                StreamWrapperManager::getStreamHandler(),
+                null
+            )
+            ->once()
+            ->andReturn($registration);
+        $registration->expects()
+            ->register()
+            ->once();
+        static::assertSame(
+            $registration,
+            StreamWrapperManager::registerStreamHandler($registrant)
+        );
+    }
+
+    public function testRegisterStreamHandlerPerformsSecondRegistrationCorrectly(): void
+    {
+        $newStreamHandler1 = mock(StreamHandlerInterface::class);
+        $newStreamHandler2 = mock(StreamHandlerInterface::class);
+        $newStreamHandler3 = mock(StreamHandlerInterface::class);
+        /** @var MockInterface&RegistrantInterface<StreamHandlerInterface> $registrant1 */
+        $registrant1 = mock(RegistrantInterface::class);
+        /** @var MockInterface&RegistrantInterface<StreamHandlerInterface> $registrant2 */
+        $registrant2 = mock(RegistrantInterface::class);
+        /** @var MockInterface&RegistrationInterface<StreamHandlerInterface> $registration1 */
+        $registration1 = mock(RegistrationInterface::class, [
+            'getStreamHandler' => $newStreamHandler1,
+        ]);
+        /** @var MockInterface&RegistrationInterface<StreamHandlerInterface> $registration2 */
+        $registration2 = mock(RegistrationInterface::class, [
+            'getStreamHandler' => $newStreamHandler2,
+        ]);
+        /** @var MockInterface&RegistrationInterface<StreamHandlerInterface> $registration3 */
+        $registration3 = mock(RegistrationInterface::class, [
+            'getStreamHandler' => $newStreamHandler3,
+        ]);
+        StreamWrapperManager::initialise();
+        $registrant1->allows()
+            ->registerStreamHandler(
+                StreamWrapperManager::getStreamHandler(),
+                null
+            )
+            ->andReturn($registration1);
+        $registration1->allows()
+            ->register();
+        // Perform first registration.
+        StreamWrapperManager::registerStreamHandler($registrant1);
+
+        // Check that second registration's replace method is able to manipulate
+        // by returning a completely different registration.
+        $registration1->expects()
+            ->replace($registration2)
+            ->once()
+            ->andReturn($registration3);
+        $registrant2->expects()
+            ->registerStreamHandler(
+                StreamWrapperManager::getStreamHandler(),
+                null
+            )
+            ->once()
+            ->andReturn($registration2);
+        $registration3->expects()
+            ->register()
+            ->once();
+        static::assertSame(
+            $registration3,
+            // Perform second registration.
+            StreamWrapperManager::registerStreamHandler($registrant2)
+        );
+    }
+
+    public function testRegisterStreamHandlerThrowsExceptionWhenNotYetInitialised(): void
+    {
+        /** @var MockInterface&RegistrantInterface<StreamHandlerInterface> $registrant */
+        $registrant = mock(RegistrantInterface::class);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Not initialised');
+
+        StreamWrapperManager::registerStreamHandler($registrant);
     }
 
     public function testSetStreamHandlerOverridesHandler(): void


### PR DESCRIPTION
Stream handlers may now be registered using a new `StreamWrapperManager::registerStreamHandler(...)` method, allowing registrations to be aware of subsequent registrations in order to manipulate the decoration chain.
Includes `->redecorate()` to allow modifying the decoration chain.